### PR TITLE
Add support OAuth 2.0 Update

### DIFF
--- a/Mail2Bug/App.config
+++ b/Mail2Bug/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
   <appSettings>
     <add key="Iterations" value="200" />
@@ -13,6 +13,7 @@
     <add key="log4net.Config.Watch" value="True" />
     <add key="ClientSettingsProvider.ServiceUri" value="" />
     <add key="Microsoft.ServiceBus.ConnectionString" value="" />
+    <add key="EnforceTls12" value="true" />
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/Mail2Bug/Config.cs
+++ b/Mail2Bug/Config.cs
@@ -130,6 +130,7 @@ namespace Mail2Bug
             public bool ApplyOverridesDuringUpdate { get; set; }
             public bool AttachOriginalMessage { get; set; }
             public bool AttachUpdateMessages { get; set; }
+            public bool EnableExperimentalHtmlFeatures { get; set; }
 
             public ProcessingStrategyType ProcessingStrategy = ProcessingStrategyType.SimpleBugStrategy;
         }

--- a/Mail2Bug/Email/EWS/EWSIncomingFileAttachment.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingFileAttachment.cs
@@ -28,6 +28,12 @@ namespace Mail2Bug.Email.EWS
             return filename;
         }
 
+        public string ContentId
+        {
+            get => _attachment.ContentId;
+            set => _attachment.ContentId = value;
+        }
+
         private static readonly ILog Logger = LogManager.GetLogger(typeof(EWSIncomingFileAttachment));
     }
 }

--- a/Mail2Bug/Email/EWS/EWSIncomingItemAttachment.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingItemAttachment.cs
@@ -38,6 +38,12 @@ namespace Mail2Bug.Email.EWS
             return filename;
         }
 
+        public string ContentId
+        {
+            get => _attachment.ContentId;
+            set => _attachment.ContentId = value;
+        }
+
         private static readonly ILog Logger = LogManager.GetLogger(typeof (EWSIncomingItemAttachment));
     }
 }

--- a/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
@@ -116,9 +116,9 @@ namespace Mail2Bug.Email.EWS
             return filename;
         }
 
-        public string GetLastMessageText()
+        public string GetLastMessageText(bool enableExperimentalHtmlFeatures)
         {
-            return EmailBodyProcessingUtils.GetLastMessageText(this);
+            return EmailBodyProcessingUtils.GetLastMessageText(this, enableExperimentalHtmlFeatures);
         }
 
         public void Delete()

--- a/Mail2Bug/Email/EmailBodyProcessingUtils.cs
+++ b/Mail2Bug/Email/EmailBodyProcessingUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -33,21 +33,30 @@ namespace Mail2Bug.Email
         {
             CQ dom = rawBody;
 
-            const string messageSeparatorStyle = "border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in";
+            const string outlookDesktopSeparatorStyle = "border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in";
+            const string outlookMobileSeparatorStyle = "display:inline-block;width:98%";
 
+            // There's no well-defined way to parse the latest email from a thread
+            // We have to use heuristics to cover different email clients
             foreach (IDomObject element in dom["*"])
             {
                 // Lots of email clients insert html elements as message delimiters which have styling but no inner text
                 // This block checks for some of these patterns
-                if (element.NodeName == "DIV")
+                if (string.Equals(element.NodeName, "div", StringComparison.OrdinalIgnoreCase) &&
+                   (element.Id == "divRplyFwdMsg" || element.Id == "x_divRplyFwdMsg" || outlookDesktopSeparatorStyle.Equals(element.GetAttribute("style"))))
                 {
-                    if (element.Id == "divRplyFwdMsg" || element.Id == "x_divRplyFwdMsg" || messageSeparatorStyle.Equals(element.GetAttribute("style")))
-                    {
-                        IDomContainer parent = element.ParentNode;
-                        element.Remove();
-                        RemoveSubsequent(parent);
-                        break;
-                    }
+                    IDomContainer parent = element.ParentNode;
+                    RemoveSubsequent(parent);
+                    parent.Remove();
+                    break;
+                }
+
+                if (string.Equals(element.NodeName, "hr", StringComparison.OrdinalIgnoreCase) &&
+                    outlookMobileSeparatorStyle.Equals(element.GetAttribute("style")))
+                {
+                    RemoveSubsequent(element);
+                    element.Remove();
+                    break;
                 }
 
                 if (!element.ChildElements.Any() && !string.IsNullOrWhiteSpace(element.InnerText))

--- a/Mail2Bug/Email/IIncomingEmailAttachment.cs
+++ b/Mail2Bug/Email/IIncomingEmailAttachment.cs
@@ -7,5 +7,6 @@
     {
         string SaveAttachmentToFile();
         string SaveAttachmentToFile(string filename);
+        string ContentId { get; set; }
     }
 }

--- a/Mail2Bug/Email/IIncomingEmailMessage.cs
+++ b/Mail2Bug/Email/IIncomingEmailMessage.cs
@@ -43,7 +43,7 @@ namespace Mail2Bug.Email
         /// messages dropped, whereas the body includes all of that "history".
         /// </summary>
         /// <returns></returns>
-        string GetLastMessageText();
+        string GetLastMessageText(bool enableExperimentalHtmlFeatures);
 
         /// <summary>
         /// Deletes the message

--- a/Mail2Bug/Email/MessageAttachmentCollection.cs
+++ b/Mail2Bug/Email/MessageAttachmentCollection.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mail2Bug.Email
+{
+    /// <summary>
+    /// Collection of Exchange email attachments that have been downloaded locally
+    /// </summary>
+    public class MessageAttachmentCollection : IDisposable
+    {
+        private readonly List<MessageAttachmentInfo> _attachments;
+        private readonly TempFileCollection _tempFileCollection;
+
+        public IReadOnlyCollection<MessageAttachmentInfo> Attachments => _attachments;
+        public IEnumerable<string> LocalFilePaths => _attachments.Select(a => a.FilePath);
+
+        public MessageAttachmentCollection()
+        {
+            _attachments = new List<MessageAttachmentInfo>();
+            _tempFileCollection = new TempFileCollection();
+        }
+
+        public void Add(string localFilePath, string contentId)
+        {
+            _attachments.Add(new MessageAttachmentInfo(localFilePath, contentId));
+            _tempFileCollection.AddFile(localFilePath, keepFile: false);
+        }
+
+        public void DeleteLocalFiles()
+        {
+            _tempFileCollection.Delete();
+        }
+
+        public void Dispose()
+        {
+            DeleteLocalFiles();
+        }
+    }
+}

--- a/Mail2Bug/Email/MessageAttachmentInfo.cs
+++ b/Mail2Bug/Email/MessageAttachmentInfo.cs
@@ -1,0 +1,18 @@
+﻿namespace Mail2Bug.Email
+{
+    /// <summary>
+    /// Represents basic information about an Exchange email attachment that has been downloaded locally and has a known exchange content id
+    /// </summary>
+    public class MessageAttachmentInfo
+    {
+        public MessageAttachmentInfo(string filePath, string contentId)
+        {
+            FilePath = filePath;
+            ContentId = contentId;
+        }
+
+        public string FilePath { get; }
+
+        public string ContentId { get; }
+    }
+}

--- a/Mail2Bug/Mail2Bug.csproj
+++ b/Mail2Bug/Mail2Bug.csproj
@@ -44,7 +44,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net">
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <HintPath>..\packages\log4net.2.0.10\lib\net40\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Common, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.Common.2.0.4\lib\net45\Microsoft.Azure.Common.dll</HintPath>

--- a/Mail2Bug/Mail2Bug.csproj
+++ b/Mail2Bug/Mail2Bug.csproj
@@ -36,6 +36,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CsQuery, Version=1.3.3.249, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CsQuery.1.3.4\lib\net40\CsQuery.dll</HintPath>
+    </Reference>
     <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
       <Private>True</Private>
@@ -320,6 +323,8 @@
     <Compile Include="MessageProcessingStrategies\DateBasedValueResolver.cs" />
     <Compile Include="MessageProcessingStrategies\IMessageProcessingStrategy.cs" />
     <Compile Include="MessageProcessingStrategies\INameResolver.cs" />
+    <Compile Include="Email\MessageAttachmentCollection.cs" />
+    <Compile Include="Email\MessageAttachmentInfo.cs" />
     <Compile Include="MessageProcessingStrategies\NameResolver.cs" />
     <Compile Include="MessageProcessingStrategies\NameResolverMock.cs" />
     <Compile Include="MessageProcessingStrategies\OverridesExtractor.cs" />

--- a/Mail2Bug/Main.cs
+++ b/Mail2Bug/Main.cs
@@ -4,6 +4,7 @@ using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using log4net;
@@ -30,6 +31,12 @@ namespace Mail2Bug
 
             try
             {
+                // Enforce TLS 1.2
+                if (ReadBoolFromAppConfig("EnforceTls12", false))
+                {
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                }
+
                 string configPath = ConfigurationManager.AppSettings["ConfigPath"];
                 string configsFilePattern = ConfigurationManager.AppSettings["ConfigFilePattern"];
 

--- a/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
@@ -21,6 +21,7 @@ namespace Mail2Bug.MessageProcessingStrategies
         public const string LocationKeyword = "##Location";
         public const string StartTimeKeyword = "##StartTime";
         public const string EndTimeKeyword = "##EndTime";
+        public const string SenderEmailKeyword = "##SenderEmail";
 
         #endregion
 
@@ -42,6 +43,7 @@ namespace Mail2Bug.MessageProcessingStrategies
             _valueResolutionMap[LocationKeyword] = message.Location;
             _valueResolutionMap[StartTimeKeyword] = GetValidTimeString(message.StartTime);
             _valueResolutionMap[EndTimeKeyword] = GetValidTimeString(message.EndTime);
+            _valueResolutionMap[SenderEmailKeyword] = message.SenderAddress;
         }
 
 
@@ -69,6 +71,7 @@ namespace Mail2Bug.MessageProcessingStrategies
         public string Location { get { return _valueResolutionMap[LocationKeyword]; } }
         public string StartTime { get { return _valueResolutionMap[StartTimeKeyword]; } }
         public string EndTime { get { return _valueResolutionMap[EndTimeKeyword]; } }
+        public string SenderEmail { get { return _valueResolutionMap[SenderEmailKeyword]; } }
 
         private string GetSender(IIncomingEmailMessage message)
         {

--- a/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
@@ -1,24 +1,29 @@
 using System.Collections.Generic;
+using Mail2Bug.Email;
 using Mail2Bug.MessageProcessingStrategies;
 
 namespace Mail2Bug.WorkItemManagement
 {
     public interface IWorkItemManager
     {
-        void AttachFiles(int workItemId, List<string> fileList);
+        void AttachFiles(int workItemId, IReadOnlyCollection<MessageAttachmentInfo> fileList);
 
         SortedList<string, int> WorkItemsCache { get; }
 
         void CacheWorkItem(int workItemId);
 
         /// <param name="values">Field Values</param>
+        /// <param name="attachments"></param>
         /// <returns>Bug ID</returns>
-        int CreateWorkItem(Dictionary<string, string> values);
+        int CreateWorkItem(Dictionary<string, string> values, MessageAttachmentCollection attachments);
 
         /// <param name="workItemId">The ID of the bug to modify </param>
         /// <param name="comment">Comment to add to description</param>
+        /// <param name="commentIsHtml"></param>
         /// <param name="values">List of fields to change</param>
-        void ModifyWorkItem(int workItemId, string comment, Dictionary<string, string> values);
+        /// <param name="attachments"></param>
+        void ModifyWorkItem(int workItemId, string comment, bool commentIsHtml, Dictionary<string, string> values,
+            MessageAttachmentCollection attachments);
 
         INameResolver GetNameResolver();
 

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using log4net;
+using Mail2Bug.Email;
 using Mail2Bug.ExceptionClasses;
 using Mail2Bug.Helpers;
 using Mail2Bug.MessageProcessingStrategies;
@@ -242,7 +243,7 @@ namespace Mail2Bug.WorkItemManagement
                 _config.TfsServerConfig.ServiceIdentityPatKeyVaultSecret);
         }
 
-        public void AttachFiles(int workItemId, List<string> fileList)
+        public void AttachFiles(int workItemId, IReadOnlyCollection<MessageAttachmentInfo> messageAttachments)
         {
             if (workItemId <= 0) return;
 
@@ -251,7 +252,11 @@ namespace Mail2Bug.WorkItemManagement
                 WorkItem workItem = _tfsStore.GetWorkItem(workItemId);
                 workItem.Open();
 
-                fileList.ForEach(file => workItem.Attachments.Add(new Attachment(file)));
+                foreach (var attachment in messageAttachments)
+                {
+                    workItem.Attachments.Add(new Attachment(attachment.FilePath));
+                }
+
                 ValidateAndSaveWorkItem(workItem);
             }
             catch (Exception exception)
@@ -261,8 +266,9 @@ namespace Mail2Bug.WorkItemManagement
         }
 
         /// <param name="values">The list of fields and their desired values to apply to the work item</param>
+        /// <param name="attachments"></param>
         /// <returns>Work item ID of the newly created work item</returns>
-        public int CreateWorkItem(Dictionary<string, string> values)
+        public int CreateWorkItem(Dictionary<string, string> values, MessageAttachmentCollection attachments)
         {
             if (values == null)
             {
@@ -294,6 +300,11 @@ namespace Mail2Bug.WorkItemManagement
                 TryApplyFieldValue(workItem, AssignedToFieldKey, values[AssignedToFieldKey]);
             }
 
+            foreach (var attachmentPath in attachments.LocalFilePaths)
+            {
+                workItem.Attachments.Add(new Attachment(attachmentPath));
+            }
+
             ValidateAndSaveWorkItem(workItem);
 
             CacheWorkItem(workItem);
@@ -302,8 +313,10 @@ namespace Mail2Bug.WorkItemManagement
 
         /// <param name="workItemId">The ID of the work item to modify </param>
         /// <param name="comment">Comment to add to description</param>
+        /// <param name="commentIsHtml"></param>
         /// <param name="values">List of fields to change</param>
-        public void ModifyWorkItem(int workItemId, string comment, Dictionary<string, string> values)
+        /// <param name="attachments"></param>
+        public void ModifyWorkItem(int workItemId, string comment, bool commentIsHtml, Dictionary<string, string> values, MessageAttachmentCollection attachments)
         {
             if (workItemId <= 0) return;
 
@@ -311,10 +324,44 @@ namespace Mail2Bug.WorkItemManagement
 
             workItem.Open();
 
-            workItem.History = comment.Replace("\n", "<br>");
+            if (commentIsHtml)
+            {
+                workItem.History = EmailBodyProcessingUtils.UpdateEmbeddedImageLinks(comment, attachments.Attachments);
+            }
+            else
+            {
+                workItem.History = comment.Replace("\n", "<br>");
+            }
+
             foreach (var key in values.Keys)
             {
                 TryApplyFieldValue(workItem, key, values[key]);
+            }
+
+            if (attachments != null)
+            {
+                string GetAttachmentKey(string fileName, long length)
+                {
+                    return  $"{fileName}|{length}";
+                }
+
+                var existingAttachments = new HashSet<string>(workItem.Attachments
+                    .OfType<Attachment>()
+                    .Select(attachment => GetAttachmentKey(attachment.Name, attachment.Length)));
+
+                foreach (var attachment in attachments.Attachments)
+                {
+                    var localFileInfo = new FileInfo(attachment.FilePath);
+                    string key = GetAttachmentKey(localFileInfo.Name, localFileInfo.Length);
+
+                    // If there's already an attachment with the same file name and size, don't bother re-uploading it
+                    // TODO: this may break embedded images for html replies since we update the img tag above to point to a local path we don't upload
+                    // However, we haven't confirmed this breaks and replying with an identical image is unlikely, so we ignore this for now
+                    if (!existingAttachments.Contains(key))
+                    {
+                        workItem.Attachments.Add(new Attachment(attachment.FilePath));
+                    }
+                }
             }
 
             ValidateAndSaveWorkItem(workItem);

--- a/Mail2Bug/packages.config
+++ b/Mail2Bug/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CsQuery" version="1.3.4" targetFramework="net45" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />

--- a/Mail2Bug/packages.config
+++ b/Mail2Bug/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="CsQuery" version="1.3.4" targetFramework="net45" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net45" />
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="log4net" version="2.0.10" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.Azure.Common" version="2.0.4" targetFramework="net45" />

--- a/Mail2BugUnitTests/AckTemplateUnitTest.cs
+++ b/Mail2BugUnitTests/AckTemplateUnitTest.cs
@@ -130,7 +130,7 @@ namespace Mail2BugUnitTests
 
             fields["Assigned To"] = null;
             fields["Priority"] = null;
-            var placeholdersWithDefaults = placeholders.Where(p => p.Field.Equals("BugOwner") || p.Field.Equals("Priority"));
+            var placeholdersWithDefaults = placeholders.Where(p => p.Field.Equals("BugOwner") || p.Field.Equals("Priority")).ToList();
             Assert.AreEqual(2, placeholdersWithDefaults.Count(), "Bad test data; all expected placeholders not found.");
 
             var workItem = new WorkItemFieldsMock(fields);

--- a/Mail2BugUnitTests/LastMessageSchemas/FromColon.expected
+++ b/Mail2BugUnitTests/LastMessageSchemas/FromColon.expected
@@ -1,0 +1,6 @@
+﻿<html><head></head><body>
+<div class="wrapppingBothMessageAndReply">
+    <p class="customStyling">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p>
+    <div>
+        <div style="border:none;border-top:solid">
+            <p class="customStyling"><b></b></p></div></div></div></body></html>

--- a/Mail2BugUnitTests/LastMessageSchemas/FromColon.orig
+++ b/Mail2BugUnitTests/LastMessageSchemas/FromColon.orig
@@ -1,0 +1,19 @@
+﻿<html>
+<body>
+<div class="wrapppingBothMessageAndReply">
+    <p class="customStyling">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p>
+    <div>
+        <div style="border:none;border-top:solid">
+            <p class="customStyling"><b>From:</b> someAddress;<br><b>Subject:</b> RE: Build error<o:p></o:p>
+            </p>
+        </div>
+    </div>
+    <p class="customStyling">
+        <o:p>&nbsp;</o:p>
+    </p>
+    <p class="customStyling">text of the reply
+    </p>
+</div>
+<div>Something after the containing div</div>
+</body>
+</html>

--- a/Mail2BugUnitTests/LastMessageSchemas/OutlookDesktopSeparator.expected
+++ b/Mail2BugUnitTests/LastMessageSchemas/OutlookDesktopSeparator.expected
@@ -1,0 +1,4 @@
+﻿<html><head></head><body>
+<div class="wrappingBothMessageAndReply">
+  <b><p class="customStyling">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p></b>
+  </div></body></html>

--- a/Mail2BugUnitTests/LastMessageSchemas/OutlookDesktopSeparator.orig
+++ b/Mail2BugUnitTests/LastMessageSchemas/OutlookDesktopSeparator.orig
@@ -1,0 +1,18 @@
+﻿<html>
+<body>
+<div class="wrappingBothMessageAndReply">
+  <b><p class="customStyling">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p></b>
+  <div>
+    <div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in">
+      <p class="customStyling">
+        <b>Old emails from: field and subject</b>
+      </p>
+    </div>
+  </div>
+  <p class="customStyling"><o:p>&nbsp;</o:p></p>
+  <div>
+      Something after the containing div
+  </div>
+</div>
+</body>
+</html>

--- a/Mail2BugUnitTests/LastMessageSchemas/OutlookMobileSeparator.expected
+++ b/Mail2BugUnitTests/LastMessageSchemas/OutlookMobileSeparator.expected
@@ -1,0 +1,10 @@
+﻿<html><head></head>
+<body>
+<div>
+  <div>
+    <div style="customStyle">Message content from iPhone</div>
+  </div>
+  <div><br></div>
+  <div class="ms-outlook-ios-signature"></div>
+</div>
+</body></html>

--- a/Mail2BugUnitTests/LastMessageSchemas/OutlookMobileSeparator.orig
+++ b/Mail2BugUnitTests/LastMessageSchemas/OutlookMobileSeparator.orig
@@ -1,0 +1,15 @@
+﻿<html><head></head>
+<body>
+<div>
+  <div>
+    <div style="customStyle">Message content from iPhone</div>
+  </div>
+  <div><br /></div>
+  <div class="ms-outlook-ios-signature"></div>
+</div>
+<hr style="display:inline-block;width:98%" tabindex="-1" />
+<div>
+    Something after the containing div
+</div>
+</body>
+</html>

--- a/Mail2BugUnitTests/Mail2BugUnitTests.csproj
+++ b/Mail2BugUnitTests/Mail2BugUnitTests.csproj
@@ -82,6 +82,24 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="LastMessageSchemas\FromColon.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\FromColon.orig">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\OutlookDesktopSeparator.orig">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\OutlookMobileSeparator.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\OutlookMobileSeparator.orig">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\OutlookDesktopSeparator.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
     <None Include="RegressionMessages\Basic.expected">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Mail2BugUnitTests/Mail2BugUnitTests.csproj
+++ b/Mail2BugUnitTests/Mail2BugUnitTests.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <HintPath>..\packages\log4net.2.0.10\lib\net40\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.2.1506.2016\lib\net40\Moq.dll</HintPath>

--- a/Mail2BugUnitTests/Mocks/Email/IncomingAttachmentMock.cs
+++ b/Mail2BugUnitTests/Mocks/Email/IncomingAttachmentMock.cs
@@ -37,6 +37,8 @@ namespace Mail2BugUnitTests.Mocks.Email
             return filename;
         }
 
+        public string ContentId { get; set; }
+
         public Exception ExceptionToThrow { get; set; }
         public byte[] Data = new byte[1];
 

--- a/Mail2BugUnitTests/Mocks/Email/IncomingEmailMessageMock.cs
+++ b/Mail2BugUnitTests/Mocks/Email/IncomingEmailMessageMock.cs
@@ -49,7 +49,7 @@ namespace Mail2BugUnitTests.Mocks.Email
             mock.CcNames = GetRandomNamesList(mock.CcAddresses.Count());
             mock.SentOn = new DateTime(Rand.Next(2012, 2525), Rand.Next(1, 12), Rand.Next(1, 28));
             mock.ReceivedOn = new DateTime(Rand.Next(2012, 2525), Rand.Next(1, 12), Rand.Next(1, 28));
-            mock.IsHtmlBody = Rand.Next(0, 1) == 0;
+            mock.IsHtmlBody = false; // this isn't html unless the creator specifically makes it so
 
             var attachments = new List<IIncomingEmailAttachment>(numAttachments);
             for (var i = 0; i < numAttachments; i++)
@@ -103,9 +103,9 @@ namespace Mail2BugUnitTests.Mocks.Email
             return filename;
         }
 
-        public string GetLastMessageText()
+        public string GetLastMessageText(bool enableExperimentalHtmlFeatures)
         {
-            return EmailBodyProcessingUtils.GetLastMessageText(this);
+            return EmailBodyProcessingUtils.GetLastMessageText(this, enableExperimentalHtmlFeatures);
         }
 
         public void CopyToFolder(string destinationFolder)

--- a/Mail2BugUnitTests/packages.config
+++ b/Mail2BugUnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="log4net" version="2.0.10" targetFramework="net45" />
   <package id="Microsoft.TestApi" version="0.6.0.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1506.2016" targetFramework="net45" />
 </packages>

--- a/Nuget.Config
+++ b/Nuget.Config
@@ -1,6 +1,6 @@
 <configuration>
     <config>
-        <add key="repositoryPath" value="..\packages" />
+        <add key="repositoryPath" value="packages" />
     </config>
 </configuration>
 

--- a/Nuget.Config
+++ b/Nuget.Config
@@ -1,0 +1,6 @@
+<configuration>
+    <config>
+        <add key="repositoryPath" value="..\packages" />
+    </config>
+</configuration>
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.7 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/opensource/security/definition), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/opensource/security/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/opensource/security/pgpkey).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc). 
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/opensource/security/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/opensource/security/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->


### PR DESCRIPTION
Can we have oAUTH 2.0 post update for Exchange Online (EXO) connections due to [Basic Auth deprecation](https://docs.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online) in Oct 1, 2022?

A configuration doc required for update for EXO. Something like the relevant code is claimed to be for VSO only. 

 <!-- The following three items (OAuthContext, OAuthResourceId, OAuthClientId) are only relevant for VSO
             These are used for ADAL based authentication to VSO. This method replaces the legacy ServiceIdentity and is
             the recommended way for authentication for VSO.
             OAuthContext is the URI for the authentication authority
             OAuthResourceId and OAuthClientId represent the resource for which we're asking for autherntication, and a
             client ID that was provisioned for authenticating our app.
             The username and password defined with ServiceIdentityUsername and ServiceidentityPasswordFile are used as 
             the credentials to authenticate with, so these are still needed even when using ADAL authentication.
             For more details on ADAL and OAuth, check out:
             http://www.cloudidentity.com/blog/2013/09/12/active-directory-authentication-library-adal-v1-for-net-general-availability/ 
        <OAuthContext></OAuthContext> 
        <OAuthResourceId></OAuthResourceId>
        <OAuthClientId></OAuthClientId>
        -->